### PR TITLE
FirewallSubscriber: use onPresenter event instead of onRequest event

### DIFF
--- a/src/EventSubscriber/FirewallSubscriber.php
+++ b/src/EventSubscriber/FirewallSubscriber.php
@@ -9,7 +9,7 @@ namespace Symnedi\Security\EventSubscriber;
 
 use Nette\Http\IRequest;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symnedi\EventDispatcher\Event\ApplicationRequestEvent;
+use Symnedi\EventDispatcher\Event\ApplicationPresenterEvent;
 use Symnedi\EventDispatcher\NetteApplicationEvents;
 use Symnedi\Security\Contract\Http\FirewallHandlerInterface;
 use Symnedi\Security\Contract\Http\FirewallMapInterface;
@@ -44,16 +44,16 @@ class FirewallSubscriber implements EventSubscriberInterface
 	 */
 	public static function getSubscribedEvents()
 	{
-		return [NetteApplicationEvents::ON_REQUEST => 'onRequest'];
+		return [NetteApplicationEvents::ON_PRESENTER => 'onPresenter'];
 	}
 
 
-	public function onRequest(ApplicationRequestEvent $applicationRequestEvent)
+	public function onPresenter(ApplicationPresenterEvent $applicationPresenterEvent)
 	{
 		/** @var FirewallHandlerInterface[] $listeners */
 		list($listeners) = $this->firewallMap->getListeners($this->request);
 		foreach ($listeners as $listener) {
-			$listener->handle($applicationRequestEvent->getApplication(), $this->request);
+			$listener->handle($applicationPresenterEvent->getApplication(), $this->request);
 		}
 	}
 

--- a/tests/EventSubscriber/FirewallSubscriberTest.php
+++ b/tests/EventSubscriber/FirewallSubscriberTest.php
@@ -9,7 +9,7 @@ use Nette\Http\Request;
 use Nette\Http\UrlScript;
 use PHPUnit_Framework_TestCase;
 use Prophecy\Argument;
-use Symnedi\EventDispatcher\Event\ApplicationRequestEvent;
+use Symnedi\EventDispatcher\Event\ApplicationPresenterEvent;
 use Symnedi\EventDispatcher\NetteApplicationEvents;
 use Symnedi\Security\Contract\Http\FirewallHandlerInterface;
 use Symnedi\Security\Contract\Http\FirewallMapInterface;
@@ -45,24 +45,23 @@ class FirewallSubscriberTest extends PHPUnit_Framework_TestCase
 	public function testGetSubscribedEvents()
 	{
 		$this->assertSame(
-			[NetteApplicationEvents::ON_REQUEST => 'onRequest'],
+			[NetteApplicationEvents::ON_PRESENTER => 'onPresenter'],
 			$this->firewall->getSubscribedEvents()
 		);
 	}
 
 
-	public function testOnRequest()
+	public function testOnPresenter()
 	{
 		$applicationMock = $this->prophesize(Application::class);
 
 		$requestMock = $this->prophesize(ApplicationRequest::class);
 		$requestMock->getParameters()->willReturn(['parameter' => 'value']);
 
-		$applicationRequestEventMock = $this->prophesize(ApplicationRequestEvent::class);
-		$applicationRequestEventMock->getApplication()->willReturn($applicationMock->reveal());
-		$applicationRequestEventMock->getRequest()->willReturn($requestMock->reveal());
+		$applicationPresenterEventMock = $this->prophesize(ApplicationPresenterEvent::class);
+		$applicationPresenterEventMock->getApplication()->willReturn($applicationMock->reveal());
 
-		$this->firewall->onRequest($applicationRequestEventMock->reveal());
+		$this->firewall->onPresenter($applicationPresenterEventMock->reveal());
 	}
 
 }


### PR DESCRIPTION
Resolve #5 (Presenter is not avaible in onRequest event)